### PR TITLE
feat: status e role do usuario como texto

### DIFF
--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/BaseUserResult.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/BaseUserResult.cs
@@ -1,6 +1,4 @@
-﻿using Ambev.DeveloperEvaluation.Domain.Enums;
-
-namespace Ambev.DeveloperEvaluation.Application.Users;
+﻿namespace Ambev.DeveloperEvaluation.Application.Users;
 
 /// <summary>
 /// Response model base for User Result operations
@@ -28,14 +26,14 @@ public class BaseUserResult
     public string Phone { get; set; } = string.Empty;
 
     /// <summary>
-    /// The user's role in the system
+    /// Gets or sets the user's role
     /// </summary>
-    public UserRole Role { get; set; }
+    public string Role { get; set; } = string.Empty;
 
     /// <summary>
     /// The current status of the user
     /// </summary>
-    public UserStatus Status { get; set; }
+    public string Status { get; set; } = string.Empty;
 }
 
 

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/CreateUser/CreateUserProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/CreateUser/CreateUserProfile.cs
@@ -14,6 +14,8 @@ public class CreateUserProfile : Profile
     public CreateUserProfile()
     {
         CreateMap<CreateUserCommand, User>();
-        CreateMap<User, CreateUserResult>();
+        CreateMap<User, CreateUserResult>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status.ToString()));
     }
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/GetUser/GetUserProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/GetUser/GetUserProfile.cs
@@ -13,6 +13,8 @@ public class GetUserProfile : Profile
     /// </summary>
     public GetUserProfile()
     {
-        CreateMap<User, GetUserResult>();
+        CreateMap<User, GetUserResult>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status.ToString()));
     }
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/ListUsers/ListUsersProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/ListUsers/ListUsersProfile.cs
@@ -7,7 +7,9 @@ public class ListUsersProfile : Profile
 {
     public ListUsersProfile()
     {
-        CreateMap<User, BaseUserResult>();
+        CreateMap<User, BaseUserResult>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status.ToString()));
     }
 }
 

--- a/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/UpdateUser/UpdateUserProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Application/Users/UpdateUser/UpdateUserProfile.cs
@@ -11,7 +11,9 @@ public class UpdateUserProfile : Profile
     public UpdateUserProfile()
     {
         CreateMap<UpdateUserCommand, User>();
-        CreateMap<User, UpdateUserResult>();
+        CreateMap<User, UpdateUserResult>()
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => src.Role.ToString()))
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status.ToString()));
     }
 
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.Domain/Enums/EnumValidatorUtil.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.Domain/Enums/EnumValidatorUtil.cs
@@ -1,0 +1,46 @@
+﻿namespace Ambev.DeveloperEvaluation.Domain.Enums;
+
+public class EnumValidatorUtil
+{
+    /// <summary>
+    /// Validates if a given string can be parsed to a specified enum type.
+    /// </summary>
+    /// <typeparam name="T">The enum type to validate against.</typeparam>
+    /// <param name="enumString">The string to validate.</param>
+    /// <returns>True if the string can be parsed to the enum type; otherwise, false.</returns>
+    public static bool BeAValidEnumString<T>(string enumString) where T : struct, Enum
+    {
+        return Enum.TryParse<T>(enumString.Trim(), true, out _);
+    }
+
+    /// <summary>
+    /// Gets the names of the values of a specified enum type, separated by commas.
+    /// </summary>
+    /// <typeparam name="T">The enum type to get the names from.</typeparam>
+    /// <param name="removeThis">The name to remove from the list of enum names.</param>
+    /// <returns>A string containing the names of the enum values, separated by commas.</returns>
+    public static string GetEnumNames<T>(string removeThis = null!) where T : Enum
+    {
+        var nameList = Enum.GetNames(typeof(T));
+
+        if (!string.IsNullOrEmpty(removeThis))
+        {
+            nameList = nameList.Where(name => !name.Equals(removeThis, StringComparison.OrdinalIgnoreCase)).ToArray();
+        }
+
+        return string.Join(", ", nameList);
+    }
+
+    /// <summary>
+    /// Converts a string to a specified enum type.
+    /// </summary>
+    /// <typeparam name="T">The enum type to convert to.</typeparam>
+    /// <param name="enumString">The string to convert.</param>
+    /// <returns>The enum value if the conversion is successful; otherwise, the default enum value.</returns>
+    public static T ConvertToEnum<T>(string enumString) where T : struct, Enum
+    {
+        return Enum.TryParse<T>(enumString.Trim(), true, out var result) ? result : default;
+    }
+}
+
+

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/BaseUserRequest.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/BaseUserRequest.cs
@@ -1,0 +1,34 @@
+﻿namespace Ambev.DeveloperEvaluation.WebApi.Features.Users;
+public class BaseUserRequest
+{
+    /// <summary>
+    /// Gets or sets the username. Must be unique and contain only valid characters.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the password. Must meet security requirements.
+    /// </summary>
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the phone number in international format (+X XXXXXXXXXX).
+    /// </summary>
+    public string Phone { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the email address. Must be a valid email format.
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the initial status of the user account.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the role assigned to the user.
+    /// </summary>
+    public string Role { get; set; } = string.Empty;
+}
+

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/BaseUserResponse.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/BaseUserResponse.cs
@@ -1,6 +1,4 @@
-﻿using Ambev.DeveloperEvaluation.Domain.Enums;
-
-namespace Ambev.DeveloperEvaluation.WebApi.Features.Users;
+﻿namespace Ambev.DeveloperEvaluation.WebApi.Features.Users;
 public class BaseUserResponse
 {
     /// <summary>
@@ -26,10 +24,10 @@ public class BaseUserResponse
     /// <summary>
     /// The user's role in the system
     /// </summary>
-    public UserRole Role { get; set; }
+    public string Role { get; set; } = string.Empty;
 
     /// <summary>
     /// The current status of the user
     /// </summary>
-    public UserStatus Status { get; set; }
+    public string Status { get; set; } = string.Empty;
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/CreateUser/CreateUserProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/CreateUser/CreateUserProfile.cs
@@ -1,4 +1,5 @@
 using Ambev.DeveloperEvaluation.Application.Users.CreateUser;
+using Ambev.DeveloperEvaluation.Domain.Enums;
 using AutoMapper;
 
 namespace Ambev.DeveloperEvaluation.WebApi.Features.Users.CreateUser;
@@ -13,7 +14,11 @@ public class CreateUserProfile : Profile
     /// </summary>
     public CreateUserProfile()
     {
-        CreateMap<CreateUserRequest, CreateUserCommand>();
+        CreateMap<CreateUserRequest, CreateUserCommand>()
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => EnumValidatorUtil.ConvertToEnum<UserStatus>(src.Status)))
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => EnumValidatorUtil.ConvertToEnum<UserRole>(src.Role)));
+
         CreateMap<CreateUserResult, CreateUserResponse>();
     }
+
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/CreateUser/CreateUserRequest.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/CreateUser/CreateUserRequest.cs
@@ -1,39 +1,9 @@
-﻿using Ambev.DeveloperEvaluation.Domain.Enums;
-
-namespace Ambev.DeveloperEvaluation.WebApi.Features.Users.CreateUser;
+﻿namespace Ambev.DeveloperEvaluation.WebApi.Features.Users.CreateUser;
 
 /// <summary>
 /// Represents a request to create a new user in the system.
 /// </summary>
-public class CreateUserRequest
+public class CreateUserRequest : BaseUserRequest
 {
-    /// <summary>
-    /// Gets or sets the username. Must be unique and contain only valid characters.
-    /// </summary>
-    public string Username { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Gets or sets the password. Must meet security requirements.
-    /// </summary>
-    public string Password { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the phone number in format (XX) XXXXX-XXXX.
-    /// </summary>
-    public string Phone { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the email address. Must be a valid email format.
-    /// </summary>
-    public string Email { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the initial status of the user account.
-    /// </summary>
-    public UserStatus Status { get; set; }
-
-    /// <summary>
-    /// Gets or sets the role assigned to the user.
-    /// </summary>
-    public UserRole Role { get; set; }
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/CreateUser/CreateUserRequestValidator.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/CreateUser/CreateUserRequestValidator.cs
@@ -27,7 +27,12 @@ public class CreateUserRequestValidator : AbstractValidator<CreateUserRequest>
         RuleFor(user => user.Username).SetValidator(new UserNameValidator());
         RuleFor(user => user.Password).SetValidator(new PasswordValidator());
         RuleFor(user => user.Phone).SetValidator(new PhoneValidator());
-        RuleFor(user => user.Status).NotEqual(UserStatus.Unknown).WithMessage("'Status' cannot be 'Unknown'");
-        RuleFor(user => user.Role).NotEqual(UserRole.None).WithMessage("'Role' cannot be 'None'");
+        RuleFor(user => user.Status)
+            .Must(EnumValidatorUtil.BeAValidEnumString<UserStatus>).WithMessage($"'Status' must be a valid value: {EnumValidatorUtil.GetEnumNames<UserStatus>("Unknown")}")
+            .NotEqual(UserStatus.Unknown.ToString()).WithMessage("'Status' cannot be 'Unknown'");
+        RuleFor(user => user.Role)
+            .Must(EnumValidatorUtil.BeAValidEnumString<UserRole>).WithMessage($"'Role' must be a valid value: {EnumValidatorUtil.GetEnumNames<UserRole>("None")}")
+            .NotEqual(UserRole.None.ToString()).WithMessage("'Role' cannot be 'None'");
     }
+
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UpdateUser/UpdateUserProfile.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UpdateUser/UpdateUserProfile.cs
@@ -1,4 +1,5 @@
 ﻿using Ambev.DeveloperEvaluation.Application.Users.UpdateUser;
+using Ambev.DeveloperEvaluation.Domain.Enums;
 using AutoMapper;
 
 namespace Ambev.DeveloperEvaluation.WebApi.Features.Users.UpdateUser;
@@ -13,7 +14,11 @@ public class UpdateUserProfile : Profile
     /// </summary>
     public UpdateUserProfile()
     {
-        CreateMap<UpdateUserRequest, UpdateUserCommand>();
+        CreateMap<UpdateUserRequest, UpdateUserCommand>()
+            .ForMember(dest => dest.Status, opt => opt.MapFrom(src => EnumValidatorUtil.ConvertToEnum<UserStatus>(src.Status)))
+            .ForMember(dest => dest.Role, opt => opt.MapFrom(src => EnumValidatorUtil.ConvertToEnum<UserRole>(src.Role)));
+
         CreateMap<UpdateUserResult, UpdateUserResponse>();
     }
+
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UpdateUser/UpdateUserRequest.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UpdateUser/UpdateUserRequest.cs
@@ -1,36 +1,6 @@
-﻿using Ambev.DeveloperEvaluation.Domain.Enums;
+﻿namespace Ambev.DeveloperEvaluation.WebApi.Features.Users.UpdateUser;
 
-namespace Ambev.DeveloperEvaluation.WebApi.Features.Users.UpdateUser;
-
-public class UpdateUserRequest
+public class UpdateUserRequest : BaseUserRequest
 {
-    /// <summary>
-    /// Gets or sets the username. Must be unique and contain only valid characters.
-    /// </summary>
-    public string Username { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Gets or sets the password. Must meet security requirements.
-    /// </summary>
-    public string Password { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the phone number in international format (+X XXXXXXXXXX).
-    /// </summary>
-    public string Phone { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the email address. Must be a valid email format.
-    /// </summary>
-    public string Email { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the initial status of the user account.
-    /// </summary>
-    public UserStatus Status { get; set; }
-
-    /// <summary>
-    /// Gets or sets the role assigned to the user.
-    /// </summary>
-    public UserRole Role { get; set; }
 }

--- a/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UpdateUser/UpdateUserRequestValidator.cs
+++ b/template/backend/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UpdateUser/UpdateUserRequestValidator.cs
@@ -24,7 +24,12 @@ public class UpdateUserRequestValidator : AbstractValidator<UpdateUserRequest>
         RuleFor(user => user.Username).SetValidator(new UserNameValidator());
         RuleFor(user => user.Password).SetValidator(new PasswordValidator());
         RuleFor(user => user.Phone).SetValidator(new PhoneValidator());
-        RuleFor(user => user.Status).NotEqual(UserStatus.Unknown).WithMessage("'Status' cannot be 'Unknown'");
-        RuleFor(user => user.Role).NotEqual(UserRole.None).WithMessage("'Role' cannot be 'None'");
+        RuleFor(user => user.Status)
+            .Must(EnumValidatorUtil.BeAValidEnumString<UserStatus>).WithMessage($"'Status' must be a valid value: {EnumValidatorUtil.GetEnumNames<UserStatus>("Unknown")}")
+            .NotEqual(UserStatus.Unknown.ToString()).WithMessage("'Status' cannot be 'Unknown'");
+        RuleFor(user => user.Role)
+            .Must(EnumValidatorUtil.BeAValidEnumString<UserRole>).WithMessage($"'Role' must be a valid value: {EnumValidatorUtil.GetEnumNames<UserRole>("None")}")
+            .NotEqual(UserRole.None.ToString()).WithMessage("'Role' cannot be 'None'");
     }
+
 }


### PR DESCRIPTION
Permitir informar Status e Role do usuário como texto e mostrar como texto #16
Ao cadastrar ou alterar um usuário, deve ser possível informar Status e Role como texto
Ao consultar um usuário, deve mostrar Status e Role como texto
As validações devem continuar funcionando, garantindo que o texto esteja na lista possível de valores